### PR TITLE
CI: allow workflow push for coverage reports

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,5 +1,8 @@
 ﻿name: Run tests
 
+permissions:
+  contents: write
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Add top-level permissions: contents: write to .github/workflows/phpunit.yml so the GITHUB_TOKEN can push coverage branches.