### PR TITLE
ci: set GITHUB_TOKEN for coverage commit

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -145,6 +145,8 @@ jobs:
 
       - name: Commit coverage summary to branch
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           git config user.name "github-actions"


### PR DESCRIPTION
Set step-level env GITHUB_TOKEN so coverage commit script can authenticate when pushing.