### PR TITLE
Fix workflow_run trigger in auto-merge-retry

### DIFF
--- a/.github/workflows/auto-merge-retry.yml
+++ b/.github/workflows/auto-merge-retry.yml
@@ -8,6 +8,7 @@ on:
   check_suite:
     types: [completed]
   workflow_run:
+    workflows: ["Run tests"]
     types: [completed]
   workflow_dispatch: {}
 


### PR DESCRIPTION
Adds workflows: ['Run tests'] to the workflow_run trigger so it references the 'Run tests' workflow and passes validation.